### PR TITLE
Support mtl 2.3 and transformers 0.6

### DIFF
--- a/microlens-ghc/microlens-ghc.cabal
+++ b/microlens-ghc/microlens-ghc.cabal
@@ -1,5 +1,5 @@
 name:                microlens-ghc
-version:             0.4.13.1
+version:             0.4.13.2
 synopsis:            microlens + array, bytestring, containers, transformers
 description:
   Use this package instead of <http://hackage.haskell.org/package/microlens microlens> if you don't mind depending on all dependencies here – @Lens.Micro.GHC@ reexports everything from @Lens.Micro@ and additionally provides orphan instances of microlens classes for packages coming with GHC (<http://hackage.haskell.org/package/array array>, <http://hackage.haskell.org/package/bytestring bytestring>, <http://hackage.haskell.org/package/containers containers>, <http://hackage.haskell.org/package/transfromers transformers>).
@@ -44,7 +44,7 @@ library
                      , bytestring >=0.9.2.1 && <0.12
                      , containers >=0.4.0 && <0.7
                      , microlens ==0.4.12.*
-                     , transformers >=0.2 && <0.6
+                     , transformers >=0.2 && <0.7
 
   ghc-options:
     -Wall -fwarn-tabs

--- a/microlens-mtl/microlens-mtl.cabal
+++ b/microlens-mtl/microlens-mtl.cabal
@@ -1,5 +1,5 @@
 name:                microlens-mtl
-version:             0.2.0.1
+version:             0.2.0.2
 synopsis:            microlens support for Reader/Writer/State from mtl
 description:
   This package contains functions (like 'view' or '+=') which work on 'MonadReader', 'MonadWriter', and 'MonadState' from the mtl package.
@@ -39,8 +39,8 @@ library
   -- other-extensions:
   build-depends:       base >=4.5 && <5
                      , microlens >=0.4 && <0.5
-                     , mtl >=2.0.1 && <2.3
-                     , transformers >=0.2 && <0.6
+                     , mtl >=2.0.1 && <2.4
+                     , transformers >=0.2 && <0.7
                      , transformers-compat >=0.4 && <1
 
   ghc-options:


### PR DESCRIPTION
Fixes #151. [mtl 2.3](https://discourse.haskell.org/t/ann-release-candidate-for-mtl-2-3/3687) removes Control.Monad.List and Control.Monad.Error as well as some Control.Monad re-exports, so include the relevant instances only if the classes exist.