### PR TITLE
Support `template-haskell-2.19`

### DIFF
--- a/microlens-th/microlens-th.cabal
+++ b/microlens-th/microlens-th.cabal
@@ -41,7 +41,7 @@ library
                      , microlens >=0.4.0 && <0.5
                      , containers >=0.5 && <0.7
                      , transformers
-                     , template-haskell >=2.8 && <2.19
+                     , template-haskell >=2.8 && <2.20
                      , th-abstraction >=0.4.1 && <0.5
 
   ghc-options:


### PR DESCRIPTION
This works when building in the `persistent` project with `allow-newer`.