### PR TITLE
Support GHC 9.4 and update CI

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,33 +8,46 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.13.20211030
+# version: 0.15.20220808
 #
-# REGENDATA ("0.13.20211030",["github","cabal.project"])
+# REGENDATA ("0.15.20220808",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+      - ci*
+  pull_request:
+    branches:
+      - master
+      - ci*
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
+    timeout-minutes:
+      60
     container:
       image: buildpack-deps:bionic
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.2.1
+          - compiler: ghc-9.4.1
             compilerKind: ghc
-            compilerVersion: 9.2.1
+            compilerVersion: 9.4.1
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.0.1
+          - compiler: ghc-9.2.4
             compilerKind: ghc
-            compilerVersion: 9.0.1
-            setup-method: hvr-ppa
+            compilerVersion: 9.2.4
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.0.2
+            compilerKind: ghc
+            compilerVersion: 9.0.2
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.7
             compilerKind: ghc
@@ -89,18 +102,18 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
             apt-add-repository -y 'ppa:hvr/ghc'
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -159,6 +172,10 @@ jobs:
             prefix: $CABAL_DIR
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
+          EOF
+          cat >> $CABAL_CONFIG <<EOF
+          program-default-options
+            ghc-options: $GHCJOBS +RTS -M3G -RTS
           EOF
           cat $CABAL_CONFIG
       - name: versions
@@ -279,7 +296,7 @@ jobs:
           ${CABAL} -vnormal check
       - name: haddock
         run: |
-          $CABAL v2-haddock $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+          $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: unconstrained build
         run: |
           rm -f cabal.project.local

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -296,7 +296,7 @@ jobs:
           ${CABAL} -vnormal check
       - name: haddock
         run: |
-          $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+          if [ $((HCNUMVER < 80200 || HCNUMVER >= 80400)) -ne 0 ] ; then $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all ; fi
       - name: unconstrained build
         run: |
           rm -f cabal.project.local

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # microlens
 
-[![Build status](https://secure.travis-ci.org/monadfix/microlens.svg)](http://travis-ci.org/monadfix/microlens)
+[![Hackage version](https://img.shields.io/hackage/v/microlens.svg?label=Hackage&color=informational)](http://hackage.haskell.org/package/microlens)
+[![microlens on Stackage Nightly](https://stackage.org/package/microlens/badge/nightly)](https://stackage.org/nightly/package/microlens)
+[![Stackage LTS version](https://www.stackage.org/package/microlens/badge/lts?label=Stackage)](https://www.stackage.org/package/microlens)
+[![Cabal build](https://github.com/stevenfontanella/microlens/workflows/Haskell-CI/badge.svg)](https://github.com/stevenfontanella/microlens/actions)
 ![BSD3 license](https://img.shields.io/badge/license-BSD3-blue.svg)
 
 *A tiny part of the lens library with no dependencies.*

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,0 +1,1 @@
+branches: master ci*

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,1 +1,3 @@
 branches: master ci*
+
+haddock: <8.1 || >8.3

--- a/microlens-contra/microlens-contra.cabal
+++ b/microlens-contra/microlens-contra.cabal
@@ -29,8 +29,9 @@ tested-with:         GHC==7.6.3
                      GHC==8.6.5
                      GHC==8.8.4
                      GHC==8.10.7
-                     GHC==9.0.1
-                     GHC==9.2.1
+                     GHC==9.0.2
+                     GHC==9.2.4
+                     GHC==9.4.1
 
 source-repository head
   type:                git

--- a/microlens-ghc/microlens-ghc.cabal
+++ b/microlens-ghc/microlens-ghc.cabal
@@ -27,8 +27,9 @@ tested-with:         GHC==7.6.3
                      GHC==8.6.5
                      GHC==8.8.4
                      GHC==8.10.7
-                     GHC==9.0.1
-                     GHC==9.2.1
+                     GHC==9.0.2
+                     GHC==9.2.4
+                     GHC==9.4.1
 
 source-repository head
   type:                git

--- a/microlens-mtl/microlens-mtl.cabal
+++ b/microlens-mtl/microlens-mtl.cabal
@@ -26,8 +26,9 @@ tested-with:         GHC==7.6.3
                      GHC==8.6.5
                      GHC==8.8.4
                      GHC==8.10.7
-                     GHC==9.0.1
-                     GHC==9.2.1
+                     GHC==9.0.2
+                     GHC==9.2.4
+                     GHC==9.4.1
 
 source-repository head
   type:                git

--- a/microlens-platform/microlens-platform.cabal
+++ b/microlens-platform/microlens-platform.cabal
@@ -27,8 +27,9 @@ tested-with:         GHC==7.6.3
                      GHC==8.6.5
                      GHC==8.8.4
                      GHC==8.10.7
-                     GHC==9.0.1
-                     GHC==9.2.1
+                     GHC==9.0.2
+                     GHC==9.2.4
+                     GHC==9.4.1
 
 source-repository head
   type:                git

--- a/microlens-th/microlens-th.cabal
+++ b/microlens-th/microlens-th.cabal
@@ -25,8 +25,9 @@ tested-with:         GHC==7.6.3
                      GHC==8.6.5
                      GHC==8.8.4
                      GHC==8.10.7
-                     GHC==9.0.1
-                     GHC==9.2.1
+                     GHC==9.0.2
+                     GHC==9.2.4
+                     GHC==9.4.1
 
 source-repository head
   type:                git
@@ -41,7 +42,7 @@ library
                      , microlens >=0.4.0 && <0.5
                      , containers >=0.5 && <0.7
                      , transformers
-                     , template-haskell >=2.8 && <2.19
+                     , template-haskell >=2.8 && <2.20
                      , th-abstraction >=0.4.1 && <0.5
 
   ghc-options:

--- a/microlens/microlens.cabal
+++ b/microlens/microlens.cabal
@@ -50,8 +50,9 @@ tested-with:         GHC==7.6.3
                      GHC==8.6.5
                      GHC==8.8.4
                      GHC==8.10.7
-                     GHC==9.0.1
-                     GHC==9.2.1
+                     GHC==9.0.2
+                     GHC==9.2.4
+                     GHC==9.4.1
 
 source-repository head
   type:                git


### PR DESCRIPTION
- Replace broken travis badge by badges for Hackage, Stackage and GitHub CI
- Bump `template-haskell`
- Bump CI to latest GHC major version
- Disable CI haddock step for GHC 8.2.2 (times out)

Subsumes
- #157  (sorry @parsonsmatt, took me a while to get CI right)