### PR TITLE
Silence new GHC 9.4 warning by adding `TypeOperators` to `default-extensions:`

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20220808
+# version: 0.15.202211107
 #
-# REGENDATA ("0.15.20220808",["github","cabal.project"])
+# REGENDATA ("0.15.202211107",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -34,14 +34,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.4.1
+          - compiler: ghc-9.4.3
             compilerKind: ghc
-            compilerVersion: 9.4.1
+            compilerVersion: 9.4.3
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.2.4
+          - compiler: ghc-9.2.5
             compilerKind: ghc
-            compilerVersion: 9.2.4
+            compilerVersion: 9.2.5
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2
@@ -196,7 +196,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -262,7 +262,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
       - name: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store

--- a/microlens-contra/microlens-contra.cabal
+++ b/microlens-contra/microlens-contra.cabal
@@ -30,8 +30,8 @@ tested-with:         GHC==7.6.3
                      GHC==8.8.4
                      GHC==8.10.7
                      GHC==9.0.2
-                     GHC==9.2.4
-                     GHC==9.4.1
+                     GHC==9.2.5
+                     GHC==9.4.3
 
 source-repository head
   type:                git

--- a/microlens-contra/microlens-contra.cabal
+++ b/microlens-contra/microlens-contra.cabal
@@ -53,3 +53,4 @@ library
 
   hs-source-dirs:      src
   default-language:    Haskell2010
+  default-extensions:  TypeOperators

--- a/microlens-ghc/microlens-ghc.cabal
+++ b/microlens-ghc/microlens-ghc.cabal
@@ -28,8 +28,8 @@ tested-with:         GHC==7.6.3
                      GHC==8.8.4
                      GHC==8.10.7
                      GHC==9.0.2
-                     GHC==9.2.4
-                     GHC==9.4.1
+                     GHC==9.2.5
+                     GHC==9.4.3
 
 source-repository head
   type:                git

--- a/microlens-ghc/microlens-ghc.cabal
+++ b/microlens-ghc/microlens-ghc.cabal
@@ -54,3 +54,4 @@ library
 
   hs-source-dirs:      src
   default-language:    Haskell2010
+  default-extensions:  TypeOperators

--- a/microlens-mtl/microlens-mtl.cabal
+++ b/microlens-mtl/microlens-mtl.cabal
@@ -51,3 +51,4 @@ library
 
   hs-source-dirs:      src
   default-language:    Haskell2010
+  default-extensions:  TypeOperators

--- a/microlens-mtl/microlens-mtl.cabal
+++ b/microlens-mtl/microlens-mtl.cabal
@@ -27,8 +27,8 @@ tested-with:         GHC==7.6.3
                      GHC==8.8.4
                      GHC==8.10.7
                      GHC==9.0.2
-                     GHC==9.2.4
-                     GHC==9.4.1
+                     GHC==9.2.5
+                     GHC==9.4.3
 
 source-repository head
   type:                git

--- a/microlens-platform/microlens-platform.cabal
+++ b/microlens-platform/microlens-platform.cabal
@@ -28,8 +28,8 @@ tested-with:         GHC==7.6.3
                      GHC==8.8.4
                      GHC==8.10.7
                      GHC==9.0.2
-                     GHC==9.2.4
-                     GHC==9.4.1
+                     GHC==9.2.5
+                     GHC==9.4.3
 
 source-repository head
   type:                git

--- a/microlens-platform/microlens-platform.cabal
+++ b/microlens-platform/microlens-platform.cabal
@@ -57,3 +57,4 @@ library
 
   hs-source-dirs:      src
   default-language:    Haskell2010
+  default-extensions:  TypeOperators

--- a/microlens-th/microlens-th.cabal
+++ b/microlens-th/microlens-th.cabal
@@ -26,8 +26,8 @@ tested-with:         GHC==7.6.3
                      GHC==8.8.4
                      GHC==8.10.7
                      GHC==9.0.2
-                     GHC==9.2.4
-                     GHC==9.4.1
+                     GHC==9.2.5
+                     GHC==9.4.3
 
 source-repository head
   type:                git

--- a/microlens-th/microlens-th.cabal
+++ b/microlens-th/microlens-th.cabal
@@ -52,6 +52,7 @@ library
 
   hs-source-dirs:      src
   default-language:    Haskell2010
+  default-extensions:  TypeOperators
 
 test-suite templates
   type: exitcode-stdio-1.0
@@ -62,4 +63,5 @@ test-suite templates
 
   build-depends: base, microlens, microlens-th, tagged
 
-  default-language: Haskell2010
+  default-language:    Haskell2010
+  default-extensions:  TypeOperators

--- a/microlens/microlens.cabal
+++ b/microlens/microlens.cabal
@@ -81,3 +81,4 @@ library
 
   hs-source-dirs:      src
   default-language:    Haskell2010
+  default-extensions:  TypeOperators

--- a/microlens/microlens.cabal
+++ b/microlens/microlens.cabal
@@ -51,8 +51,8 @@ tested-with:         GHC==7.6.3
                      GHC==8.8.4
                      GHC==8.10.7
                      GHC==9.0.2
-                     GHC==9.2.4
-                     GHC==9.4.1
+                     GHC==9.2.5
+                     GHC==9.4.3
 
 source-repository head
   type:                git

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-15.8
+resolver: lts-20.3
 
 packages:
 - microlens
@@ -8,4 +8,4 @@ packages:
 - microlens-th
 - microlens-platform
 
-compiler: ghc-8.10.1
+compiler: ghc-9.2.5


### PR DESCRIPTION
- Silence new GHC 9.4 warning by adding `TypeOperators` to `default-extensions:`
- Bump CI to 9.2.5 and 9.4.3
- Bump stack.yaml to LTS 20.3 (GHC 9.2.5)