### PR TITLE
Relax template-haskell upper bound for microlens-th

### DIFF
--- a/microlens-th/microlens-th.cabal
+++ b/microlens-th/microlens-th.cabal
@@ -42,7 +42,7 @@ library
                      , microlens >=0.4.0 && <0.5
                      , containers >=0.5 && <0.7
                      , transformers
-                     , template-haskell >=2.8 && <2.20
+                     , template-haskell >=2.8 && <2.21
                      , th-abstraction >=0.4.1 && <0.5
 
   ghc-options:


### PR DESCRIPTION
GHC 9.6.1 ships with `template-haskell-2.20.0.0`.

Tested by building the library on Windows with Stack and the `stack.yaml`:
~~~yaml
resolver: lts-20.15

packages:
- microlens
- microlens-contra
- microlens-ghc
- microlens-mtl
- microlens-th
- microlens-platform

extra-deps:
# template-haskell-2.20.0.0 is currently only a candidate package on Hackage
- url: https://hackage.haskell.org/package/template-haskell-2.20.0.0/candidate/template-haskell-2.20.0.0.tar.gz
- ghc-boot-th-9.6.1
- bytestring-0.11.4.0
- text-2.0.2
- binary-0.8.9.0
~~~