### PR TITLE
text-2.1

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -94,16 +94,6 @@ jobs:
             compilerVersion: 7.10.3
             setup-method: hvr-ppa
             allow-failure: false
-          - compiler: ghc-7.8.4
-            compilerKind: ghc
-            compilerVersion: 7.8.4
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.6.3
-            compilerKind: ghc
-            compilerVersion: 7.6.3
-            setup-method: hvr-ppa
-            allow-failure: false
       fail-fast: false
     steps:
       - name: apt

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.17.20230817
+# version: 0.17.20230827
 #
-# REGENDATA ("0.17.20230817",["github","cabal.project"])
+# REGENDATA ("0.17.20230827",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -34,9 +34,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.8.0.20230809
+          - compiler: ghc-9.8.0.20230822
             compilerKind: ghc
-            compilerVersion: 9.8.0.20230809
+            compilerVersion: 9.8.0.20230822
             setup-method: ghcup
             allow-failure: true
           - compiler: ghc-9.6.2
@@ -44,9 +44,9 @@ jobs:
             compilerVersion: 9.6.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.4.6
+          - compiler: ghc-9.4.7
             compilerKind: ghc
-            compilerVersion: 9.4.6
+            compilerVersion: 9.4.7
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.2.8
@@ -279,6 +279,7 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package microlens-th" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
+          allow-newer: text
           EOF
           if $HEADHACKAGE; then
           echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
@@ -330,6 +331,16 @@ jobs:
         run: |
           rm -f cabal.project.local
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
+      - name: prepare for constraint sets
+        run: |
+          rm -f cabal.project.local
+      - name: constraint set text-2.1
+        run: |
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='text ^>= 2.1' all --dry-run ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then cabal-plan topo | sort ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='text ^>= 2.1' --dependencies-only -j2 all ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='text ^>= 2.1' all ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='text ^>= 2.1' all ; fi
       - name: save cache
         uses: actions/cache/save@v3
         if: always()

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,20 +8,18 @@
 #
 # For more information, see https://github.com/andreasabel/haskell-ci
 #
-# version: 0.17.20231002
+# version: 0.17.20231010
 #
-# REGENDATA ("0.17.20231002",["github","cabal.project"])
+# REGENDATA ("0.17.20231010",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
   push:
     branches:
       - master
-      - ci*
   pull_request:
     branches:
       - master
-      - ci*
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
@@ -34,11 +32,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.8.0.20230929
+          - compiler: ghc-9.8.1
             compilerKind: ghc
-            compilerVersion: 9.8.0.20230929
+            compilerVersion: 9.8.1
             setup-method: ghcup
-            allow-failure: true
+            allow-failure: false
           - compiler: ghc-9.6.3
             compilerKind: ghc
             compilerVersion: 9.6.3
@@ -148,7 +146,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER >= 90800)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
+          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -177,18 +175,6 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
-          if $HEADHACKAGE; then
-          cat >> $CABAL_CONFIG <<EOF
-          repository head.hackage.ghc.haskell.org
-             url: https://ghc.gitlab.haskell.org/head.hackage/
-             secure: True
-             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
-                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
-             key-threshold: 3
-          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
-          EOF
-          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -269,11 +255,7 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package microlens-th" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
-          allow-newer: text
           EOF
-          if $HEADHACKAGE; then
-          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
-          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(microlens|microlens-contra|microlens-ghc|microlens-mtl|microlens-platform|microlens-th)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
@@ -321,16 +303,6 @@ jobs:
         run: |
           rm -f cabal.project.local
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
-      - name: prepare for constraint sets
-        run: |
-          rm -f cabal.project.local
-      - name: constraint set text-2.1
-        run: |
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='text ^>= 2.1' all --dry-run ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then cabal-plan topo | sort ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='text ^>= 2.1' --dependencies-only -j2 all ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='text ^>= 2.1' all ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='text ^>= 2.1' all ; fi
       - name: save cache
         uses: actions/cache/save@v3
         if: always()

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -6,11 +6,11 @@
 #
 #   haskell-ci regenerate
 #
-# For more information, see https://github.com/haskell-CI/haskell-ci
+# For more information, see https://github.com/andreasabel/haskell-ci
 #
-# version: 0.17.20230827
+# version: 0.17.20231002
 #
-# REGENDATA ("0.17.20230827",["github","cabal.project"])
+# REGENDATA ("0.17.20231002",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -29,19 +29,19 @@ jobs:
     timeout-minutes:
       60
     container:
-      image: buildpack-deps:bionic
+      image: buildpack-deps:focal
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.8.0.20230822
+          - compiler: ghc-9.8.0.20230929
             compilerKind: ghc
-            compilerVersion: 9.8.0.20230822
+            compilerVersion: 9.8.0.20230929
             setup-method: ghcup
             allow-failure: true
-          - compiler: ghc-9.6.2
+          - compiler: ghc-9.6.3
             compilerKind: ghc
-            compilerVersion: 9.6.2
+            compilerVersion: 9.6.3
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.4.7
@@ -222,7 +222,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: source
       - name: initial cabal.project for sdist

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ dist-newstyle/
 .cabal-sandbox/
 cabal.sandbox.config
 cabal.config
-cabal.project.local*
 cabal-dev
 stack*.yaml.lock
 TAGS

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 dist/
 dist-newstyle/
-cabal-dev
+.stack-work/
+.ghc.environment.*
 *.o
 *.hi
 *.chi
@@ -10,9 +11,10 @@ cabal-dev
 .cabal-sandbox/
 cabal.sandbox.config
 cabal.config
+cabal.project.local*
+cabal-dev
+stack*.yaml.lock
 TAGS
 .DS_Store
 *~
 *#
-.stack-work/
-dist-newstyle/

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,3 +1,12 @@
 branches: master ci*
 
 haddock: <8.1 || >8.3
+
+constraint-set text-2.1
+  ghc: >= 8.2
+  constraints: text ^>= 2.1
+  tests: True
+  run-tests: True
+
+raw-project
+  allow-newer: text

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -2,12 +2,3 @@ branches: master
 
 haddock: <8.1 || >8.3
 
--- text-2.1 is covered by GHC 9.8
--- constraint-set text-2.1
---   ghc: >= 8.2
---   constraints: text ^>= 2.1
---   tests: True
---   run-tests: True
---
--- raw-project
---   allow-newer: text

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,12 +1,13 @@
-branches: master ci*
+branches: master
 
 haddock: <8.1 || >8.3
 
-constraint-set text-2.1
-  ghc: >= 8.2
-  constraints: text ^>= 2.1
-  tests: True
-  run-tests: True
-
-raw-project
-  allow-newer: text
+-- text-2.1 is covered by GHC 9.8
+-- constraint-set text-2.1
+--   ghc: >= 8.2
+--   constraints: text ^>= 2.1
+--   tests: True
+--   run-tests: True
+--
+-- raw-project
+--   allow-newer: text

--- a/microlens-contra/microlens-contra.cabal
+++ b/microlens-contra/microlens-contra.cabal
@@ -31,7 +31,7 @@ tested-with:         GHC==7.6.3
                      GHC==8.10.7
                      GHC==9.0.2
                      GHC==9.2.8
-                     GHC==9.4.6
+                     GHC==9.4.7
                      GHC==9.6.2
                      GHC==9.8.0
 

--- a/microlens-contra/microlens-contra.cabal
+++ b/microlens-contra/microlens-contra.cabal
@@ -20,20 +20,19 @@ build-type:          Simple
 extra-source-files:
   CHANGELOG.md
 cabal-version:       >=1.10
-tested-with:         GHC==7.6.3
-                     GHC==7.8.4
-                     GHC==7.10.3
-                     GHC==8.0.2
-                     GHC==8.2.2
-                     GHC==8.4.4
-                     GHC==8.6.5
-                     GHC==8.8.4
-                     GHC==8.10.7
-                     GHC==9.0.2
-                     GHC==9.2.8
-                     GHC==9.4.7
-                     GHC==9.6.3
+tested-with:
                      GHC==9.8.0
+                     GHC==9.6.3
+                     GHC==9.4.7
+                     GHC==9.2.8
+                     GHC==9.0.2
+                     GHC==8.10.7
+                     GHC==8.8.4
+                     GHC==8.6.5
+                     GHC==8.4.4
+                     GHC==8.2.2
+                     GHC==8.0.2
+                     GHC==7.10.3
 
 source-repository head
   type:                git

--- a/microlens-contra/microlens-contra.cabal
+++ b/microlens-contra/microlens-contra.cabal
@@ -32,7 +32,7 @@ tested-with:         GHC==7.6.3
                      GHC==9.0.2
                      GHC==9.2.8
                      GHC==9.4.7
-                     GHC==9.6.2
+                     GHC==9.6.3
                      GHC==9.8.0
 
 source-repository head

--- a/microlens-contra/microlens-contra.cabal
+++ b/microlens-contra/microlens-contra.cabal
@@ -21,7 +21,7 @@ extra-source-files:
   CHANGELOG.md
 cabal-version:       >=1.10
 tested-with:
-                     GHC==9.8.0
+                     GHC==9.8.1
                      GHC==9.6.3
                      GHC==9.4.7
                      GHC==9.2.8

--- a/microlens-ghc/microlens-ghc.cabal
+++ b/microlens-ghc/microlens-ghc.cabal
@@ -30,7 +30,7 @@ tested-with:         GHC==7.6.3
                      GHC==9.0.2
                      GHC==9.2.8
                      GHC==9.4.7
-                     GHC==9.6.2
+                     GHC==9.6.3
                      GHC==9.8.0
 
 source-repository head

--- a/microlens-ghc/microlens-ghc.cabal
+++ b/microlens-ghc/microlens-ghc.cabal
@@ -18,20 +18,19 @@ build-type:          Simple
 extra-source-files:
   CHANGELOG.md
 cabal-version:       >=1.10
-tested-with:         GHC==7.6.3
-                     GHC==7.8.4
-                     GHC==7.10.3
-                     GHC==8.0.2
-                     GHC==8.2.2
-                     GHC==8.4.4
-                     GHC==8.6.5
-                     GHC==8.8.4
-                     GHC==8.10.7
-                     GHC==9.0.2
-                     GHC==9.2.8
-                     GHC==9.4.7
-                     GHC==9.6.3
+tested-with:
                      GHC==9.8.0
+                     GHC==9.6.3
+                     GHC==9.4.7
+                     GHC==9.2.8
+                     GHC==9.0.2
+                     GHC==8.10.7
+                     GHC==8.8.4
+                     GHC==8.6.5
+                     GHC==8.4.4
+                     GHC==8.2.2
+                     GHC==8.0.2
+                     GHC==7.10.3
 
 source-repository head
   type:                git

--- a/microlens-ghc/microlens-ghc.cabal
+++ b/microlens-ghc/microlens-ghc.cabal
@@ -19,7 +19,7 @@ extra-source-files:
   CHANGELOG.md
 cabal-version:       >=1.10
 tested-with:
-                     GHC==9.8.0
+                     GHC==9.8.1
                      GHC==9.6.3
                      GHC==9.4.7
                      GHC==9.2.8
@@ -43,7 +43,7 @@ library
   -- other-extensions:
   build-depends:       array >=0.3.0.2 && <0.6
                      , base >=4.5 && <5
-                     , bytestring >=0.9.2.1 && <0.12
+                     , bytestring >=0.9.2.1 && <0.13
                      , containers >=0.4.0 && <0.7
                      , microlens ==0.4.13.*
                      , transformers >=0.2 && <0.7

--- a/microlens-ghc/microlens-ghc.cabal
+++ b/microlens-ghc/microlens-ghc.cabal
@@ -29,7 +29,7 @@ tested-with:         GHC==7.6.3
                      GHC==8.10.7
                      GHC==9.0.2
                      GHC==9.2.8
-                     GHC==9.4.6
+                     GHC==9.4.7
                      GHC==9.6.2
                      GHC==9.8.0
 

--- a/microlens-mtl/microlens-mtl.cabal
+++ b/microlens-mtl/microlens-mtl.cabal
@@ -17,20 +17,19 @@ build-type:          Simple
 extra-source-files:
   CHANGELOG.md
 cabal-version:       >=1.10
-tested-with:         GHC==7.6.3
-                     GHC==7.8.4
-                     GHC==7.10.3
-                     GHC==8.0.2
-                     GHC==8.2.2
-                     GHC==8.4.4
-                     GHC==8.6.5
-                     GHC==8.8.4
-                     GHC==8.10.7
-                     GHC==9.0.2
-                     GHC==9.2.8
-                     GHC==9.4.7
-                     GHC==9.6.3
+tested-with:
                      GHC==9.8.0
+                     GHC==9.6.3
+                     GHC==9.4.7
+                     GHC==9.2.8
+                     GHC==9.0.2
+                     GHC==8.10.7
+                     GHC==8.8.4
+                     GHC==8.6.5
+                     GHC==8.4.4
+                     GHC==8.2.2
+                     GHC==8.0.2
+                     GHC==7.10.3
 
 source-repository head
   type:                git

--- a/microlens-mtl/microlens-mtl.cabal
+++ b/microlens-mtl/microlens-mtl.cabal
@@ -18,7 +18,7 @@ extra-source-files:
   CHANGELOG.md
 cabal-version:       >=1.10
 tested-with:
-                     GHC==9.8.0
+                     GHC==9.8.1
                      GHC==9.6.3
                      GHC==9.4.7
                      GHC==9.2.8

--- a/microlens-mtl/microlens-mtl.cabal
+++ b/microlens-mtl/microlens-mtl.cabal
@@ -29,7 +29,7 @@ tested-with:         GHC==7.6.3
                      GHC==9.0.2
                      GHC==9.2.8
                      GHC==9.4.7
-                     GHC==9.6.2
+                     GHC==9.6.3
                      GHC==9.8.0
 
 source-repository head

--- a/microlens-mtl/microlens-mtl.cabal
+++ b/microlens-mtl/microlens-mtl.cabal
@@ -28,7 +28,7 @@ tested-with:         GHC==7.6.3
                      GHC==8.10.7
                      GHC==9.0.2
                      GHC==9.2.8
-                     GHC==9.4.6
+                     GHC==9.4.7
                      GHC==9.6.2
                      GHC==9.8.0
 

--- a/microlens-platform/microlens-platform.cabal
+++ b/microlens-platform/microlens-platform.cabal
@@ -30,7 +30,7 @@ tested-with:         GHC==7.6.3
                      GHC==9.0.2
                      GHC==9.2.8
                      GHC==9.4.7
-                     GHC==9.6.2
+                     GHC==9.6.3
                      GHC==9.8.0
 
 source-repository head

--- a/microlens-platform/microlens-platform.cabal
+++ b/microlens-platform/microlens-platform.cabal
@@ -19,7 +19,7 @@ extra-source-files:
   CHANGELOG.md
 cabal-version:       >=1.10
 tested-with:
-                     GHC==9.8.0
+                     GHC==9.8.1
                      GHC==9.6.3
                      GHC==9.4.7
                      GHC==9.2.8

--- a/microlens-platform/microlens-platform.cabal
+++ b/microlens-platform/microlens-platform.cabal
@@ -18,20 +18,19 @@ build-type:          Simple
 extra-source-files:
   CHANGELOG.md
 cabal-version:       >=1.10
-tested-with:         GHC==7.6.3
-                     GHC==7.8.4
-                     GHC==7.10.3
-                     GHC==8.0.2
-                     GHC==8.2.2
-                     GHC==8.4.4
-                     GHC==8.6.5
-                     GHC==8.8.4
-                     GHC==8.10.7
-                     GHC==9.0.2
-                     GHC==9.2.8
-                     GHC==9.4.7
-                     GHC==9.6.3
+tested-with:
                      GHC==9.8.0
+                     GHC==9.6.3
+                     GHC==9.4.7
+                     GHC==9.2.8
+                     GHC==9.0.2
+                     GHC==8.10.7
+                     GHC==8.8.4
+                     GHC==8.6.5
+                     GHC==8.4.4
+                     GHC==8.2.2
+                     GHC==8.0.2
+                     GHC==7.10.3
 
 source-repository head
   type:                git

--- a/microlens-platform/microlens-platform.cabal
+++ b/microlens-platform/microlens-platform.cabal
@@ -29,7 +29,7 @@ tested-with:         GHC==7.6.3
                      GHC==8.10.7
                      GHC==9.0.2
                      GHC==9.2.8
-                     GHC==9.4.6
+                     GHC==9.4.7
                      GHC==9.6.2
                      GHC==9.8.0
 
@@ -48,7 +48,7 @@ library
                      , microlens-ghc ==0.4.14.*
                      , microlens-mtl ==0.2.0.*
                      , microlens-th ==0.4.3.*
-                     , text >=0.11 && <1.3 || >=2.0 && <2.1
+                     , text >=0.11 && <1.3 || >=2.0 && <2.2
                      , unordered-containers >=0.2.4 && <0.3
                      , vector >=0.9 && <0.14
 

--- a/microlens-th/microlens-th.cabal
+++ b/microlens-th/microlens-th.cabal
@@ -27,7 +27,7 @@ tested-with:         GHC==7.6.3
                      GHC==8.10.7
                      GHC==9.0.2
                      GHC==9.2.8
-                     GHC==9.4.6
+                     GHC==9.4.7
                      GHC==9.6.2
                      GHC==9.8.0
 

--- a/microlens-th/microlens-th.cabal
+++ b/microlens-th/microlens-th.cabal
@@ -16,20 +16,19 @@ build-type:          Simple
 extra-source-files:
   CHANGELOG.md
 cabal-version:       >=1.10
-tested-with:         GHC==7.6.3
-                     GHC==7.8.4
-                     GHC==7.10.3
-                     GHC==8.0.2
-                     GHC==8.2.2
-                     GHC==8.4.4
-                     GHC==8.6.5
-                     GHC==8.8.4
-                     GHC==8.10.7
-                     GHC==9.0.2
-                     GHC==9.2.8
-                     GHC==9.4.7
-                     GHC==9.6.3
+tested-with:
                      GHC==9.8.0
+                     GHC==9.6.3
+                     GHC==9.4.7
+                     GHC==9.2.8
+                     GHC==9.0.2
+                     GHC==8.10.7
+                     GHC==8.8.4
+                     GHC==8.6.5
+                     GHC==8.4.4
+                     GHC==8.2.2
+                     GHC==8.0.2
+                     GHC==7.10.3
 
 source-repository head
   type:                git

--- a/microlens-th/microlens-th.cabal
+++ b/microlens-th/microlens-th.cabal
@@ -17,7 +17,7 @@ extra-source-files:
   CHANGELOG.md
 cabal-version:       >=1.10
 tested-with:
-                     GHC==9.8.0
+                     GHC==9.8.1
                      GHC==9.6.3
                      GHC==9.4.7
                      GHC==9.2.8

--- a/microlens-th/microlens-th.cabal
+++ b/microlens-th/microlens-th.cabal
@@ -28,7 +28,7 @@ tested-with:         GHC==7.6.3
                      GHC==9.0.2
                      GHC==9.2.8
                      GHC==9.4.7
-                     GHC==9.6.2
+                     GHC==9.6.3
                      GHC==9.8.0
 
 source-repository head

--- a/microlens/microlens.cabal
+++ b/microlens/microlens.cabal
@@ -42,7 +42,7 @@ extra-source-files:
   CHANGELOG.md
 cabal-version:       >=1.10
 tested-with:
-                     GHC==9.8.0
+                     GHC==9.8.1
                      GHC==9.6.3
                      GHC==9.4.7
                      GHC==9.2.8

--- a/microlens/microlens.cabal
+++ b/microlens/microlens.cabal
@@ -53,7 +53,7 @@ tested-with:         GHC==7.6.3
                      GHC==9.0.2
                      GHC==9.2.8
                      GHC==9.4.7
-                     GHC==9.6.2
+                     GHC==9.6.3
                      GHC==9.8.0
 
 source-repository head

--- a/microlens/microlens.cabal
+++ b/microlens/microlens.cabal
@@ -41,20 +41,19 @@ build-type:          Simple
 extra-source-files:
   CHANGELOG.md
 cabal-version:       >=1.10
-tested-with:         GHC==7.6.3
-                     GHC==7.8.4
-                     GHC==7.10.3
-                     GHC==8.0.2
-                     GHC==8.2.2
-                     GHC==8.4.4
-                     GHC==8.6.5
-                     GHC==8.8.4
-                     GHC==8.10.7
-                     GHC==9.0.2
-                     GHC==9.2.8
-                     GHC==9.4.7
-                     GHC==9.6.3
+tested-with:
                      GHC==9.8.0
+                     GHC==9.6.3
+                     GHC==9.4.7
+                     GHC==9.2.8
+                     GHC==9.0.2
+                     GHC==8.10.7
+                     GHC==8.8.4
+                     GHC==8.6.5
+                     GHC==8.4.4
+                     GHC==8.2.2
+                     GHC==8.0.2
+                     GHC==7.10.3
 
 source-repository head
   type:                git

--- a/microlens/microlens.cabal
+++ b/microlens/microlens.cabal
@@ -52,7 +52,7 @@ tested-with:         GHC==7.6.3
                      GHC==8.10.7
                      GHC==9.0.2
                      GHC==9.2.8
-                     GHC==9.4.6
+                     GHC==9.4.7
                      GHC==9.6.2
                      GHC==9.8.0
 


### PR DESCRIPTION
~~Patch for template-haskell-2.21 and th-abstraction-0.6.~~

Relax `text` upper bound, test this in CI.
Does not need a re-release, just a revision on Hackage.
